### PR TITLE
update to v16

### DIFF
--- a/.github/workflows/InfinityAutoPackager.yaml
+++ b/.github/workflows/InfinityAutoPackager.yaml
@@ -4,8 +4,11 @@
 on:
   release:
     types: [published]
+  workflow_dispatch:
+
 jobs:
   InfinityAutoPackager:
+    if: github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
 
@@ -25,8 +28,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload iemod package to latest release
-        uses: svenstaro/upload-release-action@v1-release
-        if: github.ref != 'refs/heads/master'
+        uses: svenstaro/upload-release-action@2.5.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ steps.CreateIEModZipPackage.outputs.PackageBaseName }}.iemod
@@ -35,8 +37,7 @@ jobs:
           overwrite: true
 
       - name: Upload zip package to latest release
-        uses: svenstaro/upload-release-action@v1-release
-        if: github.ref != 'refs/heads/master'
+        uses: svenstaro/upload-release-action@2.5.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: ${{ steps.CreateIEModZipPackage.outputs.PackageBaseName }}.zip

--- a/c#endlessbg1/c#endlessbg1.ini
+++ b/c#endlessbg1/c#endlessbg1.ini
@@ -39,6 +39,6 @@ LabelType = GloballyUnique
 
 Type = Tweak_early
 
-Before = ACBre, ajantisbg1, atweaks, bg1re, c#brage, c#brandock, c#sodtweaks, cdtweaks, EET_End, NPC, transitions
+Before = EET_End, transitions
 
 After = bg2fixpack, JA#BGT_AdvPack, EET

--- a/c#endlessbg1/c#endlessbg1.tp2
+++ b/c#endlessbg1/c#endlessbg1.tp2
@@ -8,7 +8,7 @@
 BACKUP ~c#endlessbg1/backup~
 AUTHOR ~https://www.gibberlings3.net/forums/~ //jastey
 
-VERSION ~15~
+VERSION ~16~
 
 README ~c#endlessbg1/readme.c#endlessbg1.%LANGUAGE%.txt~ ~c#endlessbg1/readme.c#endlessbg1.english.txt~
 

--- a/c#endlessbg1/readme.c#endlessbg1.english.txt
+++ b/c#endlessbg1/readme.c#endlessbg1.english.txt
@@ -264,6 +264,10 @@ Spellhold Studios			http://www.shsforums.net/
 
 HISTORY
 
+Version 16:
+-(BGT) Corrected wrong value for "start_bg1end_sod_cutscene" (by Ychap).
+-Install order syntax for PI now only considers mods that should be installed earlier. Mods that need to be installed after EndlessBG1 are only listed if their own metadata ini-file doesn't include a check.
+
 Version 15:
 -Spanish version added, by Inueb and ElGamerViejuno.
 -Correct script name extension for script patching (compatibility code for JAP).

--- a/c#endlessbg1/readme.c#endlessbg1.french.txt
+++ b/c#endlessbg1/readme.c#endlessbg1.french.txt
@@ -263,6 +263,10 @@ Spellhold Studios			http://www.shsforums.net/
 
 HISTORY
 
+Version 16:
+-(BGT) Corrected wrong value for "start_bg1end_sod_cutscene" (by Ychap).
+-Install order syntax for PI now only considers mods that should be installed earlier. Mods that need to be installed after EndlessBG1 are only listed if their own metadata ini-file doesn't include a check.
+
 Version 15:
 -Spanish version added, by Inueb and ElGamerViejuno.
 -Correct script name extension for script patching (compatibility code for JAP).

--- a/c#endlessbg1/readme.c#endlessbg1.german.txt
+++ b/c#endlessbg1/readme.c#endlessbg1.german.txt
@@ -254,6 +254,10 @@ Spellhold Studios			http://www.shsforums.net/
 
 HISTORY
 
+Version 16:
+-(BGT) Corrected wrong value for "start_bg1end_sod_cutscene" (by Ychap).
+-Install order syntax for PI now only considers mods that should be installed earlier. Mods that need to be installed after EndlessBG1 are only listed if their own metadata ini-file doesn't include a check.
+
 Version 15:
 -Spanish version added, by Inueb and ElGamerViejuno.
 -Correct script name extension for script patching (compatibility code for JAP).

--- a/c#endlessbg1/readme.c#endlessbg1.polish.txt
+++ b/c#endlessbg1/readme.c#endlessbg1.polish.txt
@@ -282,6 +282,10 @@ Spellhold Studios - http://www.shsforums.net/
 
 HISTORIA ZMIAN:
 
+Version 16:
+-(BGT) Corrected wrong value for "start_bg1end_sod_cutscene" (by Ychap).
+-Install order syntax for PI now only considers mods that should be installed earlier. Mods that need to be installed after EndlessBG1 are only listed if their own metadata ini-file doesn't include a check.
+
 Version 15:
 -Spanish version added, by Inueb and ElGamerViejuno.
 -Correct script name extension for script patching (compatibility code for JAP).


### PR DESCRIPTION
-(BGT) Corrected wrong value for "start_bg1end_sod_cutscene" (by Ychap).
-Install order syntax for PI now only considers mods that should be installed earlier. Mods that need to be installed after EndlessBG1 are only listed if their own metadata ini-file doesn't include a check.
