### PR TITLE
update to v20.2

### DIFF
--- a/c#endlessbg1/c#endlessbg1.tp2
+++ b/c#endlessbg1/c#endlessbg1.tp2
@@ -8,7 +8,7 @@
 BACKUP ~c#endlessbg1/backup~
 AUTHOR ~https://www.gibberlings3.net/forums/~ //jastey
 
-VERSION ~20.1~
+VERSION ~20.2~
 
 README ~c#endlessbg1/readme.c#endlessbg1.%LANGUAGE%.txt~ ~c#endlessbg1/readme.c#endlessbg1.english.txt~
 
@@ -1327,8 +1327,25 @@ COPY_EXISTING ~bdintro.BCS~ ~override~
 		END ELSE BEGIN
 			PATCH_WARN ~WARNING: could not find %textToReplace% in %SOURCE_FILESPEC%~
 		END
+/* Account for EE Fixpack. Add EndCutSceneMode() if it is not present */
+		SPRINT textToCheck ~\(EndCutSceneMode()\)~
+		COUNT_REGEXP_INSTANCES ~%textToCheck%~ num_matches
+		PATCH_IF (num_matches > 0) BEGIN
+			PATCH_PRINT ~EndCutSceneMode() present in %SOURCE_FILESPEC% - no patch needed~
+		END ELSE BEGIN
+			SPRINT textToReplace ~\(SetAreaScript("",OVERRIDE)\)~
+			COUNT_REGEXP_INSTANCES ~%textToReplace%~ num_matches_2
+			PATCH_IF (num_matches_2 > 0) BEGIN
+				REPLACE_TEXTUALLY ~%textToReplace%~ ~\1
+					EndCutSceneMode()~
+				PATCH_PRINT ~Patching: Missing EndCutSceneMode() added to %SOURCE_FILESPEC%~
+			END ELSE BEGIN
+				PATCH_WARN ~WARNING: could not add EndCutSceneMode() to %SOURCE_FILESPEC%~
+			END
+		END
 	END
 BUT_ONLY
+
 
 
 <<<<<<<< .../bdintro-et.baf

--- a/c#endlessbg1/maincomponent/sarevok_cleanup.tpa
+++ b/c#endlessbg1/maincomponent/sarevok_cleanup.tpa
@@ -207,6 +207,7 @@ END
 >>>>>>>>
 EXTEND_BOTTOM ~%BaldursGateDocks_IronThrone_L2%.bcs~ ~.../ar0612_add.baf~
 
+
 /* Iron Throne, third floor: Kalessia */
 <<<<<<<< .../ar0613_add.baf
 IF
@@ -219,6 +220,7 @@ THEN
 END
 >>>>>>>>
 EXTEND_BOTTOM ~%BaldursGateDocks_IronThrone_L3%.bcs~ ~.../ar0613_add.baf~
+
 
 /* Iron Throne, 4th floor: Wirthing */
 <<<<<<<< .../ar0614_add.baf
@@ -233,6 +235,7 @@ END
 >>>>>>>>
 EXTEND_BOTTOM ~%BaldursGateDocks_IronThrone_L4%.bcs~ ~.../ar0614_add.baf~
 
+
 /* Iron Throne, 5th floor: Wirthing */
 <<<<<<<< .../ar0615_add.baf
 IF
@@ -245,6 +248,7 @@ THEN
 END
 >>>>>>>>
 EXTEND_BOTTOM ~%BaldursGateDocks_IronThrone_L5%.bcs~ ~.../ar0615_add.baf~
+
 
 /* Iron Throne, ground floor: Pang, Dhanial */
 <<<<<<<< .../ar0616_add.baf
@@ -267,6 +271,20 @@ THEN
 END
 >>>>>>>>
 EXTEND_BOTTOM ~%BaldursGateDocks_IronThrone_L1%.bcs~ ~.../ar0616_add.baf~
+
+
+/* Husam in NE Baldur's Gate ar0300 */
+<<<<<<<< .../ar0300_add.baf
+IF
+	Exists("Husam2")  // Husam
+	InMyArea("Husam2")
+	GlobalGT("SarevokBehavior","GLOBAL",0)
+THEN
+	RESPONSE #100
+		ActionOverride("Husam2",DestroySelf())
+END
+>>>>>>>>
+EXTEND_BOTTOM ~%NEBaldursGate%.bcs~ ~.../ar0300_add.baf~
 
 
 /* Addy in Central Baldur's Gate */

--- a/c#endlessbg1/readme.c#endlessbg1.english.txt
+++ b/c#endlessbg1/readme.c#endlessbg1.english.txt
@@ -316,6 +316,12 @@ Spellhold Studios			http://www.shsforums.net/
 
 HISTORY
 
+Version 20.2:
+- Spanish version revised, by ElGamerViejuno.
+- "Korlasz' Dungeon is in BG1": Fixed incompatibility with EE Fixpack that lead to intro cutscene in Korlasz' Tomb not ending.
+- In case the PC did not talk to him, Husam will no longer be waiting in NE Baldur's Gate after Sarevok is defeated to point the PC to Slythe and Kristin.
+- Added install checks so components "More Flavor to Hero of Baldur's Gate" and "Imoen and Duke Jannath" cannot be installed after component "Extended Law System" from Jarl's Adventure Pack, by Ychap.
+
 Version 20.1:
 - If Imoen is not in party and moved into Palace top floor, she should give her according greeting dialogue to the PC.
 - Install order for PI in the .ini was changed to account for Jarl's Adventure Pack v1. Recommended install order is now EndlessBG1 before JAP.

--- a/c#endlessbg1/readme.c#endlessbg1.french.txt
+++ b/c#endlessbg1/readme.c#endlessbg1.french.txt
@@ -315,6 +315,12 @@ Spellhold Studios			http://www.shsforums.net/
 
 HISTORY
 
+Version 20.2:
+- Spanish version revised, by ElGamerViejuno.
+- "Korlasz' Dungeon is in BG1": Fixed incompatibility with EE Fixpack that lead to intro cutscene in Korlasz' Tomb not ending.
+- In case the PC did not talk to him, Husam will no longer be waiting in NE Baldur's Gate after Sarevok is defeated to point the PC to Slythe and Kristin.
+- Added install checks so components "More Flavor to Hero of Baldur's Gate" and "Imoen and Duke Jannath" cannot be installed after component "Extended Law System" from Jarl's Adventure Pack, by Ychap.
+
 Version 20.1:
 - If Imoen is not in party and moved into Palace top floor, she should give her according greeting dialogue to the PC.
 - Install order for PI in the .ini was changed to account for Jarl's Adventure Pack v1. Recommended install order is now EndlessBG1 before JAP.

--- a/c#endlessbg1/readme.c#endlessbg1.german.txt
+++ b/c#endlessbg1/readme.c#endlessbg1.german.txt
@@ -307,6 +307,12 @@ Spellhold Studios			http://www.shsforums.net/
 
 HISTORY
 
+Version 20.2:
+- Spanish version revised, by ElGamerViejuno.
+- "Korlasz' Dungeon is in BG1": Fixed incompatibility with EE Fixpack that lead to intro cutscene in Korlasz' Tomb not ending.
+- In case the PC did not talk to him, Husam will no longer be waiting in NE Baldur's Gate after Sarevok is defeated to point the PC to Slythe and Kristin.
+- Added install checks so components "More Flavor to Hero of Baldur's Gate" and "Imoen and Duke Jannath" cannot be installed after component "Extended Law System" from Jarl's Adventure Pack, by Ychap.
+
 Version 20.1:
 - If Imoen is not in party and moved into Palace top floor, she should give her according greeting dialogue to the PC.
 - Install order for PI in the .ini was changed to account for Jarl's Adventure Pack v1. Recommended install order is now EndlessBG1 before JAP.

--- a/c#endlessbg1/readme.c#endlessbg1.polish.txt
+++ b/c#endlessbg1/readme.c#endlessbg1.polish.txt
@@ -338,6 +338,12 @@ Spellhold Studios - http://www.shsforums.net/
 
 HISTORIA ZMIAN:
 
+Version 20.2:
+- Spanish version revised, by ElGamerViejuno.
+- "Korlasz' Dungeon is in BG1": Fixed incompatibility with EE Fixpack that lead to intro cutscene in Korlasz' Tomb not ending.
+- In case the PC did not talk to him, Husam will no longer be waiting in NE Baldur's Gate after Sarevok is defeated to point the PC to Slythe and Kristin.
+- Added install checks so components "More Flavor to Hero of Baldur's Gate" and "Imoen and Duke Jannath" cannot be installed after component "Extended Law System" from Jarl's Adventure Pack, by Ychap.
+
 Version 20.1:
 - If Imoen is not in party and moved into Palace top floor, she should give her according greeting dialogue to the PC.
 - Install order for PI in the .ini was changed to account for Jarl's Adventure Pack v1. Recommended install order is now EndlessBG1 before JAP.

--- a/c#endlessbg1/translations/spanish/DIALOGUES.TRA
+++ b/c#endlessbg1/translations/spanish/DIALOGUES.TRA
@@ -1,77 +1,77 @@
 /* dialogues_ee.d */
-@0 = ~<CHARNAME>, ¡Lo habéis conseguido! Habéis derrotado a Sarevok, quien conspiró contra la ciudad de la Costa de la Espada, incluso contra Amn, por sus oscuros objetivos y propósitos.~
-@1 = ~Abristeis nuestros ojos al engaño y nos salvasteis de un gran peligro mientras permanecíamos ciegos ante tal amenaza. Por el poder que me ha sido otorgado como Duque del Consejo de los Cuatro de esta ciudad, yo os nombro "Héroe de Puerta de Baldur". En nombre de la ciudad, permíteme expresarte nuestra más profunda gratitud.~ ~Abristeis nuestros ojos al engaño y nos salvasteis de un gran peligro mientras permanecíamos ciegos ante tal amenaza. Por el poder que me ha sido otorgado como Duque del Consejo de los Cuatro de esta ciudad, yo os nombro "Heroína de Puerta de Baldur". En nombre de la ciudad, permíteme expresarte nuestra más profunda gratitud.~
-@2 = ~<CHARNAME>, Héroe de Puerta de Baldur, ¿estáis listo para combinar fuerzas con el Puño Llameante e ir contra los últimos seguidores de Sarevok?~ ~<CHARNAME>, Heroína de Puerta de Baldur, ¿estáis lista para combinar fuerzas con el Puño Llameante e ir contra los últimos seguidores de Sarevok?~
-@3 = ~"Héroe de Puerta de Baldur", eso si que suena bien. Decidme que necesitáis que haga.~ ~"Heroína de Puerta de Baldur", eso si que suena bien. Decidme que necesitáis que haga.~
-@4 = ~Si, estoy listo y comenzare de inmediato. Envíadme a donde me necesitéis.~ ~Si, estoy lista y comenzare de inmediato. Envíadme a donde me necesitéis.~
-@5 = ~En realidad, ya tuve suficiente de cumplir un papel. No seré un lacayo tuyo ni de nadie. Dejo Puerta de Baldur para buscar mi destino en otra parte. Que os vaya bien.~
-@6 = ~No de inmediato. Tengo algunas cosas que terminar primero.~
-@7 = ~La ciudad esta en deuda contigo, Héroe de Puerta de Baldur. Por favor, seguidme, os diré lo que sabemos.~ ~La ciudad esta en deuda contigo, Heroína de Puerta de Baldur. Por favor, seguidme, os diré lo que sabemos.~
-@8 = ~Ya veo. Aún así, la ciudad esta en deuda con vos. Que os vaya bien, Heroe de Puerta de Baldur.~ ~Ya veo. Aún así, la ciudad esta en deuda con vos. Que os vaya bien, Heroína de Puerta de Baldur.~
+@0 = ~<CHARNAME>, ¡Lo habéis conseguido! Habéis derrotado a Sarevok, que conspiraba contra la ciudad, la Costa de la Espada, e incluso Amn, para alcanzar sus oscuros objetivos y propósitos.~
+@1 = ~Nos abristeis los ojos ante el engaño y nos salvasteis de un gran peligro cuando permanecíamos ciegos ante la amenaza. Por el poder que me ha sido otorgado como duque del Consejo de los Cuatro de esta ciudad, ¡os nombro "Héroe de Puerta de Baldur"! En nombre de la ciudad, permitidme expresaros nuestra más profunda gratitud.~ ~Nos abristeis los ojos ante el engaño y nos salvasteis de un gran peligro cuando permanecíamos ciegos ante la amenaza. Por el poder que me ha sido otorgado como duque del Consejo de los Cuatro de esta ciudad, ¡os nombro "Heroína de Puerta de Baldur"! En nombre de la ciudad, permitidme expresaros nuestra más profunda gratitud.~
+@2 = ~<CHARNAME>, Héroe de Puerta de Baldur, ¿estáis listo para unir fuerzas con el Puño Llameante y enfrentaros a los últimos seguidores de Sarevok?~ ~<CHARNAME>, Heroína de Puerta de Baldur, ¿estáis lista para unir fuerzas con el Puño Llameante y enfrentaros a los últimos seguidores de Sarevok?~
+@3 = ~"Héroe de Puerta de Baldur", eso suena muy bien. Decidme que necesitáis que haga.~ ~"Heroína de Puerta de Baldur", eso suena muy bien. Decidme que necesitáis que haga.~
+@4 = ~Si, estoy listo y empezaré de inmediato. Enviadme donde me necesitéis.~ ~Si, estoy lista y empezaré de inmediato. Enviadme donde me necesitéis.~
+@5 = ~En realidad, ya estoy harto de cumplir un papel. No seré el lacayo de nadie. Voy a abandonar Puerta de Baldur para buscar mi destino en otra parte. Que os vaya bien.~ ~En realidad, ya estoy harta de cumplir un papel. No seré el lacaya de nadie. Voy a abandonar Puerta de Baldur para buscar mi destino en otra parte. Que os vaya bien.~
+@6 = ~No de inmediato. Primero tengo que terminar algunas cosas.~
+@7 = ~La ciudad esta en deuda con vos, Héroe de Puerta de Baldur. Por favor, seguidme, os contaré lo que sabemos.~ ~La ciudad esta en deuda con vos, Heroína de Puerta de Baldur. Por favor, seguidme, os contaré lo que sabemos.~
+@8 = ~Entiendo. Aún así, la ciudad esta en deuda con vos. Que os vaya bien, Héroe de Puerta de Baldur.~ ~Entiendo. Aún así, la ciudad esta en deuda con vos. Que os vaya bien, Heroína de Puerta de Baldur.~
 @9 = ~Muy bien. Concentraremos nuestras fuerzas en encontrar a todos los seguidores de Sarevok y esperamos que pronto os unáis a nuestros esfuerzos. Hasta entonces, disfrutad de vuestra estancia.~
 
 /* dialogues.d */ 
 @10 = ~¡Gracias por derrotar a Sarevok, <CHARNAME>!~
 
-/* nuevo para v2 */
+/* new for v2 */
 /* dialogues.d */
-@11 = ~Mi agradecimiento para vos también, compañero de <CHARNAME>.~ ~Mi agradecimiento para vos también, compañera de <CHARNAME>.~
+@11 = ~Mi agradecimiento también para vos, compañero de <CHARNAME>.~
 
 /* dialogues_ee.d */
-@12 = ~Saludos a vos también, compañero de <CHARNAME>.~ ~Saludos a vos también, compañera de <CHARNAME>.~
+@12 = ~Saludos también para vos, compañero de <CHARNAME>.~
 
-/* nuevo para v3: cambiada la línea 7 para SoD [de nuevo dividida en v9] */
+/* new for v3: changed line 7 for SoD [again splitted in v9] */
 @13 = ~La ciudad está en deuda con vos, Héroe de Puerta de Baldur.~ ~La ciudad está en deuda con vos, Heroína de Puerta de Baldur.~
 
-/* nuevo para v9: línea 13 dividida */
-@14 = ~Por favor, seguidme, los soldados del Puño Llameante os guiarán hasta el escondite del última seguidora de Sarevok.~
+/* new for v9: splitted line 13 */
+@14 = ~Seguidme, por favor, los soldados del Puño Llameante os guiarán hasta el escondite de la última seguidora de Sarevok.~
 
 /* pc_palaceresidence.d */
 @20 = ~Saludos, <CHARNAME>. Por favor, abandonad el sótano, no deberíais estar aquí.~
 @21 = ~Saludos, <CHARNAME>.~
 @22 = ~Saludos, Héroe de Puerta de Baldur.~ ~Saludos, Heroína de Puerta de Baldur.~
-@23 = ~Entra, <CHARNAME>. Los Duques desean hablar con vos.~
+@23 = ~Entrad, <CHARNAME>. Los duques desean hablar con vos.~
 /* BG:EE: #7548 */
-@24 = ~Entrad directamente.~
+@24 = ~Entrad.~
 /* BG:EE: #7550 */
-@25 = ~Moveos amigos, sólo aseguraos de no causar problemas.~ 
+@25 = ~Seguid adelante amigos, pero procurad no causar problemas.~ 
 /* BG:EE: #9010 */
-@26 = ~Hay otras cosas que debo atender ahora. Buenos días.~
+@26 = ~Ahora tengo otras cosas que atender. Que tengáis un buen día.~
 /* BG:EE: #5157 */
-@27 = ~Así que nos encontramos de nuevo. Lo siento, pero no tengo tiempo para hablar con vos.~
+@27 = ~Así que nos volvemos a encontrar. Lo siento, pero no tengo tiempo para hablar.~
 /* BG:EE: #7477 */
 @28 = ~Haced lo que queráis, e id donde os plazca.~
 /* BG:EE: #9340 */
-@29 = ~Soy un orgulloso miembro del Puño Llameante. Nuestro cuartel general está en Puerta de Baldur, aunque también operamos en Beregost y el Brazo Amigo. Estamos bastante preocupados por la repentina escasez del hierro. Muchos piensan que la nación de Amn se está preparando para la guerra contra nuestra gran ciudad. Si este fuera el caso, no sé lo bien que nos iría, careciendo de un recurso tan importante como el hierro.~
-@30 = ~¡Bienvenido, Héroe de Puerta de Baldur! Esta habitación os servirá de residencia mientras permanezcáis en la ciudad. He preparado todo y espero que sea de vuestro agrado. Los Duques quieren que os diga que el cofre en el extremo izquierdo de la habitación sera para vuestro uso personal, y todo lo que pongáis dentro se quedará allí mientras toméis residencia aquí. Hemos vaciado los cofres y trasladado todo al piso de abajo, pero si hemos pasado algo por alto, sentiros libre de tratarlo como si fuera vuestro. ¡Que tengáis una buena estancia y gracias por salvar la ciudad!~ ~¡Bienvenida, Heroína de Puerta de Baldur! Esta habitación os servirá de residencia mientras permanezcáis en la ciudad. He preparado todo y espero que sea de vuestro agrado. Los Duques quieren que os diga que el cofre en el extremo izquierdo de la habitación sera para vuestro uso personal, y todo lo que pongáis dentro se quedará allí mientras toméis residencia aquí. Hemos vaciado los cofres y trasladado todo al piso de abajo, pero si hemos pasado algo por alto, sentiros libre de tratarlo como si fuera vuestro. ¡Que tengáis una buena estancia y gracias por salvar la ciudad!~
+@29 = ~Soy un orgulloso miembro del Puño Llameante. Nuestro cuartel general está en Puerta de Baldur, aunque también operamos en Beregost y el Brazo Amigo. Estamos bastante preocupados por la repentina escasez del hierro. Muchos piensan que la nación de Amn se está preparando para la guerra contra nuestra gran ciudad. Si este fuera el caso, no sé cómo nos iría, al carecer de un recurso tan importante como el hierro.~
+@30 = ~¡Bienvenido, Héroe de Puerta de Baldur! Esta habitación será vuestra residencia mientras permanezcáis en la ciudad. He preparado todo y espero que sea de vuestro agrado. Los duques me han pedido que os diga que el baúl que hay en el extremo izquierdo de la habitación será para vuestro uso personal, y todo lo que guardéis en él permanecerá allí mientras residáis aquí. Hemos vaciado los baúles y lo hemos trasladado todo al piso de abajo, pero si se nos ha pasado algo por alto, no dudéis en considerarlo vuestro. ¡Que tengáis una buena estancia y gracias por salvar la ciudad!~ ~¡Bienvenida, Heroína de Puerta de Baldur! Esta habitación será vuestra residencia mientras permanezcáis en la ciudad. He preparado todo y espero que sea de vuestro agrado. Los duques me han pedido que os diga que el baúl que hay en el extremo izquierdo de la habitación será para vuestro uso personal, y todo lo que guardéis en él permanecerá allí mientras residáis aquí. Hemos vaciado los baúles y lo hemos trasladado todo al piso de abajo, pero si se nos ha pasado algo por alto, no dudéis en considerarlo vuestro. ¡Que tengáis una buena estancia y gracias por salvar la ciudad!~
 
 /* ceremony_sod.d */
 @40 = ~¡Por favor, seguidme!~
-@41 = ~<CHARNAME> de Candelero!~
-@42 = ~¡Con el título vienen aposentos oficiales para vos en el tercer nivel del Palacio Ducal! Los sirvientes os ayudarán a instalaros tan pronto como estéis listo. ¡Todos, alabad a nuestro Héroe de Puerta de Baldur!~ ~¡Con el título vienen aposentos oficiales para vos en el tercer nivel del Palacio Ducal! Los sirvientes os ayudarán a instalaros tan pronto como estéis listo. ¡Todos, alabad a nuestra Heroína de Puerta de Baldur!~
+@41 = ~¡<CHARNAME> de Candelero!~
+@42 = ~¡Con el título vienen los aposentos oficiales para vos en el tercer nivel del Palacio Ducal! Los sirvientes os ayudarán a instalaros tan pronto como estéis listo. ¡Todos, alabemos a nuestro Héroe de Puerta de Baldur!~ ~¡Con el título vienen los aposentos oficiales para vos en el tercer nivel del Palacio Ducal! Los sirvientes os ayudarán a instalaros tan pronto como estéis lista. ¡Todos, alabemos a nuestra Heroína de Puerta de Baldur!~
 
 /* imoen_jannath.d */
-@50 = ~¡Quien hubiera pensado que era un conspirador tan malvado! Y casi lo convertimos en Duque... Nos salvasteis a todos, y estamos en deuda con vos, <CHARNAME>, ¡Héroe de Puerta de Baldur! Te mereces el titulo.~ ~¡Quien hubiera pensado que era un conspirador tan malvado! Y casi lo convertimos en Duque... Nos salvasteis a todos, y estamos en deuda con vos, <CHARNAME>, ¡Heroína de Puerta de Baldur! Os merecéis el título.~
-@51 = ~¡Eso suena tan impresionante! "Héroe de Puerta de Baldur".~ ~¡Eso suena tan impresionante! "Heroína de Puerta de Baldur".~
-@52 = ~¡Si tan solo hubiera podido utilizar magia, entonces lo hubieramos derribado aún más rápido!~
-@53 = ~¿Magia, dices? Hmm...~
-@54 = ~Imoen, creo que tenéis talento para la magia. Puede que quiera hablar con vos más tarde, joven amiga.~
-@55 = ~¿Yo? Uhm... ¡bien!~
-@56 = ~¡Bienvenido, Héroe de Puerta de Baldur! Y bienvenida, Imoen. Esta habitacion será vuestra residencia mientras permanezcáis en la ciudad, Imoen - con saludos de la Duquesa Jannath.~ ~¡Bienvenida, Heroína de Puerta de Baldur! Y bienvenida, Imoen. Esta habitacion será vuestra residencia mientras permanezcáis en la ciudad, Imoen - con saludos de la Duquesa Jannath.~
+@50 = ~¡Quien hubiera pensado que era un conspirador tan malvado! Y casi lo convertimos en duque... Nos salvasteis a todos, y estamos en deuda con vos, <CHARNAME>, ¡Héroe de Puerta de Baldur! Os merecéis el titulo.~ ~¡Quien hubiera pensado que era un conspirador tan malvado! Y casi lo convertimos en duque... Nos salvasteis a todos, y estamos en deuda con vos, <CHARNAME>, ¡Heroína de Puerta de Baldur! Os merecéis el título.~
+@51 = ~¡Suena impresionante! "Héroe de Puerta de Baldur".~ ~¡Suena impresionante! "Heroína de Puerta de Baldur".~
+@52 = ~¡Si hubiera podido usar la magia, lo habríamos derrotado aún más rápido!~
+@53 = ~¿Magia, decís? Hmm...~
+@54 = ~Imoen, creo que tenéis talento para la magia. Quizás quiera hablar con vos más tarde, joven amiga.~
+@55 = ~¿Yo? Uhm... ¡vale!~
+@56 = ~¡Bienvenido, Héroe de Puerta de Baldur! Y bienvenida, Imoen. Esta habitacion será vuestra residencia mientras permanezcáis en la ciudad, Imoen, con los saludos de la Duquesa Jannath.~ ~¡Bienvenida, Heroína de Puerta de Baldur! Y bienvenida, Imoen. Esta habitacion será vuestra residencia mientras permanezcáis en la ciudad, Imoen, con los saludos de la Duquesa Jannath.~
 @57 = ~...¿Mía? ¡Oh, wow! ¡Gracias!~
-@58 = ~Vos también tenéis un cofre propio, Imoen. Es el que está en el extremo izquierdo de la habitación. Todo lo que pongáis dentro os quedará allí mientras viváis aquí. ¡Que tengáis una buena estancia!~
-@59 = ~¡<CHARNAME>! "Héroe de Puerta de Baldur", ¿eh? ¡Impresionante! La Duquesa Jannath me ofreció esta habitación, ¡junto con lecciones de magia! ¿Os lo imagináis? Estaremos en la misma suite, ¡Vos y yo! Pero preferiría viajar con vos otra vez.~ ~¡<CHARNAME>! "Heroína de Puerta de Baldur", ¿eh? ¡Impresionante! La Duquesa Jannath me ofreció esta habitación, ¡junto con lecciones de magia! ¿Os lo imagináis? Estaremos en la misma suite, ¡Vos y yo! Pero preferiría viajar con vos otra vez.~
-@60 = ~El cofre en el extremo izquierdo de la habitación es mío, por cierto. En caso de que necesitéis más espacio para guardar vuestro equipo - dijeron que el cofre sería mío mientras nos quedásemos aquí.~
+@58 = ~Vos también tenéis un baúl propio, Imoen. Es el que está en el extremo izquierdo de la habitación. Todo lo que pongáis dentro os quedará allí mientras viváis aquí. ¡Que tengáis una buena estancia!~
+@59 = ~¡<CHARNAME>! "Héroe de Puerta de Baldur", ¿eh? ¡Impresionante! La Duquesa Jannath me ofreció esta habitación, ¡junto con lecciones de magia! ¿Os lo imagináis? Estaremos en la misma suite, ¡Vos y yo! Pero preferiría seguir viajando con vos.~ ~¡<CHARNAME>! "Heroína de Puerta de Baldur", ¿eh? ¡Impresionante! La Duquesa Jannath me ofreció esta habitación, ¡junto con lecciones de magia! ¿Os lo imagináis? Estaremos en la misma suite, ¡Vos y yo! Pero preferiría seguir viajando con vos.~
+@60 = ~Por cierto, el baúl en el extremo izquierdo de la habitación es mío. Por si necesitáis más espacio para guardar vuestras cosas, me han dicho que el baúl será mío mientras nos alojemos aquí.~
 
-/* nuevo para v2 */
-@61 = ~Saludos, Imoen. Si encontráis tiempo para entrenar magia, hacérmelo saber.~
+/* new for v2 */
+@61 = ~Saludos, Imoen. Si encontráis tiempo para entrenar magia, hacédmelo saber.~
 @62 = ~Hola, Imoen. Venid a verme más tarde, ¿queréis?~
 @63 = ~Hola, Imoen. Mi oferta de clases de magia sigue en pie, tan pronto como <CHARNAME> pueda prescindir de vos.~
-@64 = ~¿Estáis segura? Podría quedarme en el Palacio y aceptaros la oferta de la Duquesa Jannath.~
+@64 = ~¿Estáis seguro? Podría quedarme en el palacio y aceptar la oferta de la Duquesa Jannath.~ ~¿Estáis segura? Podría quedarme en el palacio y aceptar la oferta de la Duquesa Jannath.~
 @65 = ~Sí, Imoen, hacedlo.~
-@66 = ~En realidad, me gustaría que esperarais en otro lugar.~
-@67 = ~Mi culpa, quédaos conmigo.~
-@68 = ~¡Lo haré! La Duquesa Jannath se arrepentirá enseguida... No os alejéis mucho, ¿queréis?~
+@66 = ~En realidad, preferiría que esperarais en otro lugar.~
+@67 = ~Perdonad, quedaos conmigo.~
+@68 = ~¡Lo haré! La Duquesa Jannath se arrepentirá enseguida... No tardéis mucho, ¿vale?~
 
 
 
@@ -81,126 +81,126 @@
 @71 = ~Buenos días para vos.~
 
 /* ffhealer.d */
-@80 = ~¡<CHARNAME>! Los Duques nos enviaron para velar por vuestro bienestar. Nos encargaremos de los cuerpos de Sarevok y sus secuaces.~
-@81 = ~¿Queréis que os curemos y desarmemos las trampas restantes también?~
+@80 = ~¡<CHARNAME>! Los duques nos han enviado para ver cómo estáis. Nosotros nos encargaremos de los cuerpos de Sarevok y sus secuaces.~
+@81 = ~¿Queréis que os curemos y desactivemos las trampas que quedan?~
 @82 = ~Sí, por favor.~
-@83 = ~No gracias, puedo apañarmelas solo.~
-@84 = ~Habéis hecho una gran obra por la ciudad. Regresad al Palacio y hablad con los Duques, desean agradeceros. Que os vaya bien.~
-@85 = ~Con mucho gusto. Por favor esperad un momento...~
-@86 = ~Eso debería bastar.~
+@83 = ~No gracias, puedo apañarmelas solo.~ ~No gracias, puedo apañarmelas sola.~
+@84 = ~Habéis hecho un gran servicio a la ciudad. Regresad al palacio y hablad con los duques, quieren daros las gracias. Que os vaya bien.~
+@85 = ~Con mucho gusto. Por favor, quedaos quieto un momento...~ ~Con mucho gusto. Por favor, quedaos quieta un momento...~
+@86 = ~Ya está.~
 
 /* elminster.d */
-@90 = ~Nuestros caminos se cruzan una vez mas, joven. Te has enterado de tu herencia divina y no sólo eso, sino que has tenido que matar a uno de tus devotos hermanos. Habéis librado a la Costa de la Espada de un gran mal. La pregunta es, ¿qué camino seguiréis a partir de ahora? ¿Sucumbiréis al mal que corre por vuestras venas? Tened la seguridad de que hay gente buena observando, <CHARNAME>, velando por vos y preparada para lo que sea que hagáis en el futuro, lo mejor que puedo haceros es desearos lo mejor, <CHARNAME>, hijo de Bhaal. Que los dioses os bendigan en todo el camino que os queda por delante.~
+@90 = ~Nuestros caminos se cruzan una vez más, joven. Habéis descubierto vuestra herencia divina y, no solo eso, sino que habéis tenido que matar a uno de vuestros hermanos divinos. Habéis librado a la Costa de la Espada de un gran mal. La pregunta es, ¿qué camino seguiréis a partir de ahora? ¿Sucumbiréis al mal que corre por vuestras venas? Tened la seguridad de que hay gente buena observándoos, <CHARNAME>, velando por vos y preparada para lo que sea que hagáis en el futuro, lo mejor que puedo haceros es desearos lo mejor, <CHARNAME>, hijo de Bhaal. Que los dioses os bendigan en todo el camino que os queda por delante.~ ~Nuestros caminos se cruzan una vez más, joven. Habéis descubierto vuestra herencia divina y, no solo eso, sino que habéis tenido que matar a uno de vuestros hermanos divinos. Habéis librado a la Costa de la Espada de un gran mal. La pregunta es, ¿qué camino seguiréis a partir de ahora? ¿Sucumbiréis al mal que corre por vuestras venas? Tened la seguridad de que hay gente buena observándoos, <CHARNAME>, velando por vos y preparada para lo que sea que hagáis en el futuro, lo mejor que puedo haceros es desearos lo mejor, <CHARNAME>, hija de Bhaal. Que los dioses os bendigan en todo el camino que os queda por delante.~
 
-/* nuevo para v2 */
+/* new for v2 */
 //#12741
-@91 = ~¡Hola! Parece que vuestros viajes resultaron para bien después de todo. Sin embargo, no esperéis grandes elogios por el asesinato de Sarevok. Imagino que todo el incidente será silenciado inmediatamente. Sin embargo, tened por seguro, que muchos de los ciudadanos prominentes de los reinos saben de vuestro servicio y os lo agradecen. Una palabra amistosa de advertencia, sin embargo. Esos mismos ciudadanos están vigilando. Procuraos no suponer una amenaza como lo fue vuestro hermano, no sea que otro grupo de jóvenes héroes tenga que ser enviado para ocuparse de vos. Que la suerte os acompañe.~
+@91 = ~¡Hola, amigo! Parece que vuestros viajes han salido bien después de todo. Sin embargo, no esperaría muchos elogios por haber matado a Sarevok. Imagino que todo el incidente se silenciará rápidamente. Pero tened por seguro que muchos de los ciudadanos prominentes de los reinos conocen vuestros servicios y os están agradecidos. Sin embargo, os doy un consejo amistoso. Esos mismos ciudadanos os están observando. Procurad no suponer una amenaza tan grande como la que representaba vuestro hermano, no sea que tengan que enviar a otro grupo de jóvenes héroes para ocuparse de vos. Que la suerte os acompañe.~ ~¡Hola, amiga! Parece que vuestros viajes han salido bien después de todo. Sin embargo, no esperaría muchos elogios por haber matado a Sarevok. Imagino que todo el incidente se silenciará rápidamente. Pero tened por seguro que muchos de los ciudadanos prominentes de los reinos conocen vuestros servicios y os están agradecidos. Sin embargo, os doy un consejo amistoso. Esos mismos ciudadanos os están observando. Procurad no suponer una amenaza tan grande como la que representaba vuestro hermano, no sea que tengan que enviar a otro grupo de jóvenes héroes para ocuparse de vos. Que la suerte os acompañe.~
 //#12742
-@92 = ~Veo que habéis sobrevivido a las pruebas y tribulaciones os han puesto por delante. No puedo deciros que esté muy satisfecho con eso, con vuestro comportamiento en general. La destrucción de Sarevok es un pobre consuelo si estáis decidido a seguir la misma senda homicida. Meditad bien vuestro camino y el destino os espera. Sería una pena que terminarais vuestra vida de la misma manera que vuestro hermano.~
+@92 = ~Veo que habéis sobrevivido a las pruebas y tribulaciones que se os han presentado. No puedo decir que me complazca demasiado, teniendo en cuenta vuestro comportamiento en general. La destrucción de Sarevok es un pequeño consuelo si estáis decidido a seguir sus pasos asesinos. Considerad bien vuestro camino y vuestro destino. Sería una pena veros terminar vuestra vida de la misma manera que vuestro hermano.~ ~Veo que habéis sobrevivido a las pruebas y tribulaciones que se os han presentado. No puedo decir que me complazca demasiado, teniendo en cuenta vuestro comportamiento en general. La destrucción de Sarevok es un pequeño consuelo si estáis decidida a seguir sus pasos asesinos. Considerad bien vuestro camino y vuestro destino. Sería una pena veros terminar vuestra vida de la misma manera que vuestro hermano.~
 //#12743
-@93 = ~¡Hola! Un final glorioso para este desagradable asunto, ¿verdad? Sin embargo, no esperéis grandes elogios por vuestros esfuerzos, ya que es probable que este asunto se silencie lo antes posible. Aún así, muchos en el reino saben de vuestra batalla y os tienen en alta estima por ello. Un gran mal ha sido derrotado. Esperemos que otros con esta desafortunada herencia no busquen el mismo camino.~
+@93 = ~¡Hola! Un final glorioso para este desagradable asunto, ¿no es así? Sin embargo, no esperéis grandes elogios por vuestros esfuerzos, ya que es probable que este asunto se silencie lo antes posible. Aún así, muchos en el reino conocen vuestra batalla y os tienen en alta estima por ello. Se ha derrotado a un gran mal. Esperemos que otros con esta desafortunada herencia no sigan el mismo camino.~
 
 /* dialogues_sarevoksword_bgt.d */
-@100 = ~Lo siento mucho, pero tengo que obedecer a mi amo, y quitaros esta espada... Ah, jaja, no estarán muy contentos de ver el estado en que se encuentra. Oh bueno, supongo que ya se en que voy a gastar mi tiempo ahora. Que te vaya bien, <CHARNAME>, tal vez nos volvamos a ver en otras circunstancias.~
+@100 = ~Lo siento mucho, pero debo obedecer a mi amo y quitaros esta espada... Ah, jaja, no les va a hacer mucha gracia ver el estado en que está. Bueno, supongo que ya sé en qué voy a ocupar mi tiempo a partir de ahora. Que os vaya bien, <CHARNAME>, quizá nos volvamos a encontrar en otras circunstancias.~
 
 /* dialogues_sarevoksword_ee.d */
 @110 = ~Primero, dejadme daros la espada de Sarevok, como pedisteis.~
-@111 = ~Hemos notado que Sarevok se vinculó con su espada y la convirtió en un arma muy poderosa.~
-@112 = ~Veo que también tomasteis su armadura. Seguirá siendo vuestra, aunque sólo puedo advertiros que no la useis - aparecer con el mismo atuendo oscuro y amenazador podría levantar desafortunadas sospechas en la gente.~
-@113 = ~Nos gustaría llevarnos la espada y mantenerla a salvo. Si nos la dierais, os estaríamos agradecidos. Os recompensaremos como corresponde, por supuesto.~
-@114 = ~¡En efecto! Yo mismo tengo curiosidad por ver un arma así, poderosa tanto en magia como en valor simbólico para sus seguidores. Oh - pero veo que perdió mucho de su poder, y no es utilizable en el estado actual. Mejor - cualquiera que quiera empuñarla y ponerse en la piel de Sarevok tendrá que pagar mucho oro para que recupere parte de su antiguo poder.~
-@115 = ~Sin embargo, tiene un alto valor simbólico para sus últimos seguidores. Tenemos que guardarla bien, ya que atraerá a muchos ladrones. Gracias, <CHARNAME>, por otorgarnos esta arma y darnos la oportunidad de eliminar este símbolo maligno de estas tierras. Permitidme daros esta espada como compensación, así como esta pequeña suma de oro como pequeña muestra de nuestra gratitud.~
+@111 = ~Hemos observado que Sarevok se vinculó con su espada y la convirtió en un arma muy poderosa.~
+@112 = ~Veo que también tomasteis su armadura. Seguirá siendo vuestra, aunque os advierto que no la uséis, ya que aparecer con el mismo atuendo oscuro y amenazador podría despertar sospechas desafortunadas en la gente.~
+@113 = ~Nos gustaría quedarnos con la espada y mantenerla a salvo. Si nos la entregáis, os estaremos muy agradecidos. Por supuesto, os recompensaremos como corresponde.~
+@114 = ~¡Por supuesto! Yo mismo tengo curiosidad por ver un arma así, poderosa tanto en magia como en valor simbólico para sus seguidores. Oh, pero veo que ha perdido mucho de su poder y no se puede usar en su estado actual. Mejor así: cualquiera que quiera empuñarla y seguir los pasos de Sarevok tendrá que pagar mucho oro para que recupere al menos parte de su antiguo poder.~
+@115 = ~No obstante, tiene un gran valor simbólico para sus últimos seguidores. Debemos protegerla bien, ya que atraerá a muchos ladrones. Gracias, <CHARNAME>, por concedernos esta arma y darnos la oportunidad de eliminar este símbolo maligno de nuestras tierras. Permitidme daros esta espada como compensación, así como esta pequeña suma de oro como muestra de nuestra gratitud.~
 
 /* refugees_sod.d */
-@120 = ~Viajamos hasta aquí desde Páramo Alto porque quemaron nuestras granjas. No sabemos quiénes son, sólo que siguen ahí fuera y que su número va en aumento. ¿Nos ayudará Puerta de Baldur? Nunca llegamos tan lejos en el sur, pero no nos sentimos seguros fuera de una gran ciudad.~
-@121 = ~Quemaron todo - después de llevarse todo nuestro ganado. ¿Por qué alguien haría eso?~
-@122 = ~Tantos hombres furiosos, y destruyen todo a su paso. Realmente espero que estemos a salvo aquí en el sur.~
-@123 = ~Nos pidieron que nos uniéramos a ellos, y entonces empezaron a arrasar y matar... Huimos con lo poco que pudimos llevar.~
-@124 = ~Destruyeron toda la aldea - y no quiero ni saber lo que le hicieron a los aldeanos que no huyeron lo suficientemente pronto.~
+@120 = ~Viajamos hasta aquí desde Páramo Alto porque quemaron nuestras granjas. No sabemos quiénes son, sólo que siguen ahí fuera y que su número sigue creciendo. ¿Nos ayudará Puerta de Baldur? Nunca habíamos llegado tan al sur, pero no nos sentimos seguros fuera de una gran ciudad.~
+@121 = ~Lo quemaron todo, después de llevarse todo nuestro ganado. ¿Por qué haría alguien algo así?~
+@122 = ~Tantos hombres furiosos, y lo destruyen todo a su paso. Realmente espero que estemos a salvo aquí en el sur.~
+@123 = ~Nos pidieron que nos uniéramos a ellos, y luego empezaron a arrasar y matar... Huimos con lo poco que pudimos llevar.~
+@124 = ~Destruyeron todo la aldea, ¡y ni siquiera quiero saber lo que le hicieron a los aldeanos que no huyeron a tiempo!~
 @125 = ~¡Uniros a nosotros! ¡Uniros a nosotros en una cruzada de saqueos y matanzas! ¡Esos asesinos pidieron que nos uniéramos a ellos! Huí tan pronto como pude.~
-@126 = ~¡Maaamaaa! El extraño me está hablando.~
-@127 = ~Perdí mi cachorro en el camino.~
-@128 = ~Quiero regresar a casa.~
+@126 = ~¡Maaamaaa! El extraño me está hablando.~ ~¡Maaamaaa! La extraña me está hablando.~
+@127 = ~Perdí mi peluche en el camino.~
+@128 = ~Quiero irme a casa.~
 
 /* denkod.d */
 @140 = ~¡Habéis vuelto!~
 @141 = ~Tengo que deciros, tened cuidado con usar eso. Por un momento pensé que erais él. Casi saco mi daga, y os la clavo en el pecho.~
-@142 = ~No os vais a creer lo que ha pasado aquí hace unos minutos. Los mercenarios del Puño Llameante, que se paseaban por el gremio y nos ignoraban a todos, primero entraban y luego salían.~
-@143 = ~Parece que el grupo de ahí abajo está acabado, ¿eh? ¿También liquidasteis a ese tipo con armadura, o volverá a pasar por aquí también? Por ahora me iré a un lugar más tranquilo, ¡aquí hay demasiado tráfico para mi gusto!~
+@142 = ~No os vais a creer lo que ha pasado aquí hace unos minutos. Los mercenarios del Puño Llameante entraron pisando fuerte en el gremio, ignorándonos a todos, primero entraron y luego salieron.~
+@143 = ~Parece que la fiesta de abajo ha terminado, ¿eh? ¿Acabasteis con ese tipo con armadura o volverá a pasar por aquí también? Me voy a un lugar más tranquilo, por ahora, ¡hay demasiado tráfico aquí para mi gusto!~
 
 /* ophyllis_sod.d */
-@150 = ~¡Oh, <CHARNAME>! Encantado de conoceros. Soy Ophyllis, el tesorero del Palacio Ducal. Os guardaré vuestro oro para cuando os unáis al Puño Llameante en la persecución de los últimos de los seguidores de Sarevok.~
-@151 = ~¿El tesorero del Palacio Ducal? Eso suena como una posición de alta responsabilidad.~
+@150 = ~¡Oh, <CHARNAME>! Encantado de conoceros. Soy Ophyllis, el tesorero del Palacio Ducal. Guardaré vuestro oro mientras os unís a las fuerzas del Puño Llameante en la persecución de los últimos seguidores de Sarevok.~
+@151 = ~¿El tesorero del Palacio Ducal? Parece un cargo de gran responsabilidad~
 @152 = ~¿Guardar mi oro? ¿Por qué?~
 @153 = ~¿Qué pasa si no quiero daros mi oro?~
 @154 = ~Sé quién sois. Que tengáis un buen día.~
-@155 = ~¡Oh, así es! Jaja. Los Duques confían en mí sin dudarlo. ¡Saben que nunca tomaría una sola moneda para mi beneficio!~
-@156 = ~Es por orden de los Duques, me temo - nadie marchando con el Puño Llameante debería tener que preocuparse por su riqueza - y para ser honesto, creo que a los Duques les gusta la idea de que los hombres no tengan monedas de sobra para visitas no oficiales a la taberna, ejem.~
-@157 = ~Mantendré vuestro oro a buen recaudo, no hay razón para preocuparos ahora, jaja - Tengo que prepararme para la custodia de vuestro oro, la nota al respecto me llegó hace unos momentos.~
-@158 = ~Iré a veros una vez que os hayáis unido al Puño Llameante en su persecución. ¡Adiós hasta entonces!~
+@155 = ~¡Oh, así es! Jaja. Los duques confían plenamente en mí. ¡Saben que nunca tomaría una sola moneda para mi beneficio!~
+@156 = ~Me temo que es una orden de los duques: nadie que marche con el Puño Llameante debería preocuparse por su riqueza y, para ser sincero, creo que a los duques les gusta la idea de que los hombres no tengan monedas de sobra para visitas no oficiales a la taberna, ejem.~
+@157 = ~Mantendré vuestro oro a buen recaudo, no hay razón para preocuparos ahora, jaja... Tengo que prepararme para la custodia de vuestro oro, la nota al respecto me ha llegado hace solo unos momentos.~
+@158 = ~Me pondré en contacto con vos cuando os hayáis unido al Puño Llameante en su persecución. ¡Que os vaya bien hasta entonces!~
 @159 = ~Saludos, <CHARNAME>. Si estáis aquí para ver a Ophyllis, él debe estar en la oficina.~
 
 /* korlasz_dungeon_bg1.d */
-/* líneas @200 - @202 son las mismas que @0 - @2 de ajantisbg1/.../ajantisbg1_transitions.tra */
+/* lines @200 - @202 are the same as  @0 - @2 from ajantisbg1/.../ajantisbg1_transitions.tra */
 @200 = ~Ha sido un honor limpiar este lugar de la amenaza de los bandidos y de la creciente guerra con vos. Mi tarea aquí ha terminado. Volveré a casa para llamar a la Orden del Radiante Corazón. Informaré de los sucesos y de vuestra participación en ellos. Yo, ejem, también mencionaré mi parte en ello, y espero que se me considere digno de recibir el título de caballero. Os agradezco por unir fuerzas conmigo. ¡Adiós!~
-@201 = ~<CHARNAME>, me temo que ha llegado el momento de deciros adiós. La guerra ha terminado, Sarevok ha sido derrotado, la tarea que me encomendó la Orden está cumplida. Es hora de que me presente, pero antes viajaré a Aguas Profundas, como ya acordamos. Nada me detendrá de buscar la respuesta de mis padres respecto a nuestros planes de matrimonio, ahora que nuestro enemigo ha sido derrotado y la paz ha vuelto a las tierras, por fin. Tengo tantas ganas de hablar con ellos, <CHARNAME>, mi amor. Hablad con ellos y contarles el amor que siento a por vos.~
-@202 = ~Mi corazón sufre por dejaros. Os enviaré mensajes sobre mi paradero tan a menudo como pueda. Y ya sea en Aguas Profundas, Athkatla, o aquí donde nos volvamos a encontrar, ten por seguro que vendré a por vos - o os esperaré, no importa donde estemos destinados a reunirnos. Adiós, "Heroína de Puerta de Baldur" (sonríe). Disfrutad de la gratitud y los elogios de la gente mientras aún estén dispuestos a dároslos, <CHARNAME>. Os lo habéis ganado.~
-@203 = ~Imoen - La Duquesa Jannath quiere hablaros antes de que os vayáis.~
+@201 = ~<CHARNAME>, me temo que ha llegado el momento de deciros adiós. La guerra ha terminado, Sarevok ha sido derrotado, la tarea que me encomendó la Orden está cumplida. Es hora de que me presente, pero antes viajaré a Aguas Profundas, como ya acordamos. Nada me impedirá buscar la respuesta de mis padres sobre nuestros planes de matrimonio, ahora que nuestro enemigo ha sido derrotado y la paz ha vuelto por fin a estas tierras. Estoy deseando hablar con ellos, <CHARNAME>, mi amor. Hablar con ellos y contarles el amor que siento por vos.~
+@202 = ~Mi corazón sufre por dejaros. Os enviaré mensajes sobre mi paradero tan a menudo como pueda. Y ya sea en Aguas Profundas, Athkatla, o aquí donde nos volvamos a encontrar, tened por seguro que vendré a por vos, o os esperaré, no importa donde estemos destinados a reunirnos. Adiós, "Heroína de Puerta de Baldur" (sonríe). Disfrutad de la gratitud y los elogios de la gente mientras aún estén dispuestos a dároslos, <CHARNAME>. Os lo habéis ganado.~
+@203 = ~Imoen, la Duquesa Jannath quiere hablaros antes de que os vayáis.~
 @204 = ~Imoen, niña, quiero hablaros antes que os vayáis. Venid aquí un momento.~
-@205 = ~¿Yo? De acuerdo.~
+@205 = ~¿Yo? ¡De acuerdo!~
 @206 = ~La Duquesa Jannath está decidida a ver a Imoen antes de os vayais. Estoy seguro de que también se ocupará del estado actual de vuestra amiga.~
 @207 = ~Necesito hablar con Imoen antes de que os vayais. Llamaré a Fenster para que se ocupe de su estado actual.~
 @208 = ~Imoen, vuestra amiga de la infancia, fue preparada por la Duquesa Jannath para guiaros lo mejor posible. Ella os esperará allí.~
 @209 = ~Por favor, regresad a la cripta familiar de Korlasz y ayudad a derrotar a la última seguidora de Sarevok.~
-@210 = ~<CHARNAME>, Héroe de Puerta de Baldur. ¡Volvéis victorioso! No solo el mismo Sarevok, sino tambien todos los seguidores de Sarevok han sido derrotados.~ ~<CHARNAME>, Heroína de Puerta de Baldur. ¡Volvéis victoriosa! No solo el mismo Sarevok, sino tambien todos los seguidores de Sarevok han sido derrotados.~
+@210 = ~<CHARNAME>, Héroe de Puerta de Baldur. ¡Habéis regresado victorioso! No solo el mismo Sarevok, sino también todos los seguidores de Sarevok han sido derrotados.~ ~<CHARNAME>, Heroína de Puerta de Baldur. ¡Habéis regresado victoriosa! No solo el mismo Sarevok, sino también todos los seguidores de Sarevok han sido derrotados.~
 @211 = ~Honestamente, necesito un descanso. Puedo sentir el siguiente problema creciendo en las sombras. Descansaré y no haré nada por un tiempo así estaré preparado para lo que venga.~
 @212 = ~Todavía hay mucho que hacer y descubrir. Estaré por aquí.~
 @213 = ~Me iré de la ciudad y de la Costa de la Espada antes de que ocurra la próxima catástrofe que amenace al mundo. Intentaré ir hacia el sur, lejos de lo que la ciudad de Puerta de Baldur pueda sufrir en un futuro cercano o lejano.~
 @214 = ~Un héroe siempre está ocupado. Quien reciba vuestra ayuda puede considerarse afortunado. Disfrutad vuestro tiempo, héroe.~ ~Una heroína siempre está ocupada. Quien reciba vuestra ayuda puede considerarse afortunado. Disfrutad vuestro tiempo, heroína.~
 @215 = ~Un merecido descanso. Sentiros como en casa en el último piso del palacio tanto como queráis.~
-@216 = ~Ahora voy a hacer mi propio camino. Que os vaya bien, <CHARNAME>.~
-@217 = ~Ya me voy, <CHARNAME>. Fue genial y todo, pero voy a ir a disfrutar de un merecido descanso por un tiempo.~
-@218 = ~He soportado vuestras excentricidades bastante tiempo, <CHARNAME>, pero esta fue la última tumba a la que tú, o cualquier otro me atraiga.~
-@219 = ~Partiré y veré que tareas me tiene reservadas mi protector.~
-@220 = ~Ooh sí, dormir y no hacer *nada*, ¡eso suena genial! Aunque... Creo que aceptaré la oferta de la Duquesa Jannath de entrenarme en la magia, <CHARNAME>. Id a tomar vuestro merecido descanso, dormilón.~
-@221 = ~Habéis demostrado ser el héroe de la ciudad, y estamos en deuda con vos para siempre. ¿Qué haréis ahora?~ ~Habéis demostrado ser la heroína de la ciudad, y estamos en deuda con vos para siempre. ¿Qué haréis ahora?~
-/* @222 - @225 son los mismos que en "imoen_forever/.../IMOEN_IN_GROUP_KD.TRA". */
+@216 = ~Ahora seguiré mi propio camino. Que os vaya bien, <CHARNAME>.~
+@217 = ~Me voy, <CHARNAME>. Ha sido genial, pero voy a ir a disfrutar de un merecido descanso por un tiempo.~
+@218 = ~He soportado vuestras excentricidades bastante tiempo, <CHARNAME>, pero esta fue la última tumba a la que vos, o cualquier otro me atraiga.~
+@219 = ~Partiré y veré que tareas me tiene reservadas mi patrón.~
+@220 = ~Ooh sí, dormir y no hacer *nada*, ¡eso suena genial! Aunque... Creo que aceptaré la oferta de la Duquesa Jannath de entrenarme en la magia, <CHARNAME>. Id a tomar vuestro merecido descanso, dormilón.~ ~Ooh sí, dormir y no hacer *nada*, ¡eso suena genial! Aunque... Creo que aceptaré la oferta de la Duquesa Jannath de entrenarme en la magia, <CHARNAME>. Id a tomar vuestro merecido descanso, dormilona.~
+@221 = ~Habéis demostrado ser el héroe de la ciudad, y estamos en deuda con vos para siempre. ¿Qué vais hacer ahora?~ ~Habéis demostrado ser la heroína de la ciudad, y estamos en deuda con vos para siempre. ¿Qué vais hacer ahora?~
+/* @222 - @225 are the same as in "imoen_forever/.../IMOEN_IN_GROUP_KD.TRA". */
 @222 = ~<CHARNAME>, ¡Encontré un montón de viejos tomos, investigaciones y demás!~
-@223 = ~Aquí está, Duquesa Liia. ¡Mirad el tamaño de esa pila!~
+@223 = ~Aquí están, Duquesa Liia. ¡Mirad el tamaño de esa pila!~
 @224 = ~Os agradezco los tomos que me trajo Imoen. Tomad esto como compensación.~
-@225 = ~Estoy muy interesada en estos viejos tomos que encontraste en la cripta familiar de Korlasz para mi investigación. Por favor, entregádmelos tan pronto como podáis, <CHARNAME>.~
+@225 = ~Estoy muy interesada en estos viejos tomos que encontrasteis en la cripta familiar de Korlasz para mi investigación. Por favor, entregádmelos tan pronto como podáis, <CHARNAME>.~
 
-@226 = ~Encontrasteis tomos sobre Bhaal en las posesiones de Korlasz. ¿Puedo tenerlos para mi propia investigación?~
+@226 = ~Encontrasteis tomos sobre Bhaal en las posesiones de Korlasz. ¿Puedo quedármelos para mi propia investigación?~
 @227 = ~Por supuesto. Aquí tenéis.~
 @228 = ~No, me gustaría conservarlos.~
 
-/* @229 es lo mismo que @229 en "imoen_forever/.../IMOEN_IN_GROUP_KD.TRA". */
+/* @229 is the same as @229 in "imoen_forever/.../IMOEN_IN_GROUP_KD.TRA". */
 @229 = ~Os doy las gracias. Tomad esto como compensación.~
 
 @230 = ~Ya veo. Por favor, dádmelos tan pronto como podáis disponer de ellos.~
-@231 = ~Estoy muy interesado en estudiar este tipo de tomos antiguos.~
+@231 = ~Estoy muy interesada en estudiar este tipo de tomos antiguos.~
 
-/* @232 es lo mismo que @232 en "imoen_forever/.../IMOEN_IN_GROUP_KD.TRA". */
+/* @232 is the same as @232 in "imoen_forever/.../IMOEN_IN_GROUP_KD.TRA". */
 @232 = ~Aquí hay una investigación sobre nigromancia y Bhaal que encontré en la cripta familiar de Korlasz. Creo que os puede interesar.~
-@233 = ~[Dynaheir]Os habéis convertido en un poderoso hijo de Bhaal. Vuestro viaje no ha concluido aún, y el nuestro tampoco.~
+@233 = ~[Dynaheir]Os habéis convertido en un poderoso hijo de Bhaal. Vuestro viaje no ha concluido aún, y el nuestro tampoco.~ ~[Dynaheir]Os habéis convertido en una poderosa hija de Bhaal. Vuestro viaje no ha concluido aún, y el nuestro tampoco.~
 @234 = ~[Minsc]Habrá más maldad que patear, y Bubú dijo que esto es algo que Minsc debería esperar.~
-@235 = ~[Jaheira]Habéis recorrido un largo camino. Le prometimos a Gorion que velaríamos por vos, y superasteis cualquier ayuda que pudiéramos daros para luchar contra vuestros enemigos. A partir de ahora, seremos nosotros los que os vigilaremos para que no sucumbas ante vuestra herencia.~
+@235 = ~[Jaheira]Habéis recorrido un largo camino. Le prometimos a Gorion que velaríamos por vos, y superasteis cualquier ayuda que pudiéramos daros para luchar contra vuestros enemigos. A partir de ahora, seremos nosotros los que os vigilaremos para que no sucumbáis ante vuestra herencia.~
 @236 = ~[Khalid]G-Gorion estaría orgulloso de vuestros logros. Iremos con vos y os ayudaremos con cualquier t-tarea que pueda surgir.~
 @237 = ~Ooh sí, dormir y no hacer *nada*, ¡suena genial! Aunque... hablando desde la experiencia, ¡no creo que los dioses nos dejen!~
 
-@238 = ~Tomad esto también. No es un objeto mágico poderoso, pero os será útil - un héroe necesita tener sus llaves a mano para no perder tiempo crucial por una cosa tan trivial.~
+@238 = ~Tomad esto también. No es un objeto mágico poderoso, pero os será útil... un héroe debe tener sus llaves a mano para no perder un tiempo crucial por algo tan trivial.~
 
 /* pc_palaceresidence.d */
-/* nuevo para v9 */
-@350 = ~Esta confortable cama ofrece lujos que nunca encontrasteis en Candelero.~
+/* new for v9 */
+@350 = ~Esta confortable cama ofrece un lujo que nunca encontrasteis en Candelero.~
 @351 = ~Os tumbáis para dormir toda la noche (8 horas).~
 @352 = ~Pasáis el tiempo hasta medianoche.~
 @353 = ~Pasáis el tiempo hasta las once de la noche.~
-@354 = ~Pasáis el tiempo hasta el mediodía.~
-@355 = ~Pasáis el tiempo hasta las once del mediodía.~
-@356 = ~Pasáis el tiempo hasta las diez del mediodía.~
-@357 = ~Pasáis el tiempo hasta que amanecer (6 am).~
-@358 = ~Pasáis el tiempo hasta que termina el amanecer (7 am).~
-@359 = ~Pasáis el tiempo hasta que empieza a anochecer (9 pm).~
-@360 = ~Pasáis el tiempo hasta que termina el crepúsculo (10 pm).~
+@354 = ~Pasáis el tiempodío hasta el media.~
+@355 = ~Pasáis el tiempo hasta las once de la mañana.~
+@356 = ~Pasáis el tiempo hasta las diez de la mañana.~
+@357 = ~Pasáis el tiempo hasta que amanece (6 am).~
+@358 = ~Pasáis el tiempo hasta que amanece (7 am).~
+@359 = ~Pasáis el tiempo hasta que empieza a atardecer (9 pm).~
+@360 = ~Pasáis el tiempo hasta que termina el atardecer (10 pm).~
 @361 = ~Os alejáis de la cama.~

--- a/c#endlessbg1/translations/spanish/GAME.TRA
+++ b/c#endlessbg1/translations/spanish/GAME.TRA
@@ -1,28 +1,28 @@
 /* @0 = */
-@1 = ~La armadura de placas es la mejor armadura que un guerrero puede comprar, tanto en apariencia como en protección. Las placas entrelazadas y perfectamente ajustadas están especialmente anguladas para desviar flechas y golpes, y todo el traje está cuidadosamente adornado con ricos grabados y detalles en relieve.  
+@1 = ~La armadura de placas completa es la mejor armadura que un guerrero puede comprar, tanto en apariencia como en protección. Las placas entrelazadas y perfectamente ajustadas están especialmente anguladas para desviar flechas y golpes, y todo el traje está cuidadosamente adornado con ricos grabados y detalles en relieve.  
 
 Esta inusual armadura pesada perteneció a Sarevok.
 
 CARACTERÍSTICAS:
 
 Clase de Armadura: -1
-Peso: 70
+Peso: 70 lbs
 Requisitos: Fuerza 15
 No utilizable por:
  Bardo
  Druida
  Ladrón~
-@2 = ~La armadura de placas completas es la mejor armadura que un guerrero puede comprar, tanto en apariencia como en protección. Las placas entrelazadas y perfectamente ajustadas están especialmente anguladas para desviar flechas y golpes, y todo el traje está cuidadosamente adornado con ricos grabados y detalles en relieve.  
+@2 = ~La armadura de placas completa es la mejor armadura que un guerrero puede comprar, tanto en apariencia como en protección. Las placas entrelazadas y perfectamente ajustadas están especialmente anguladas para desviar flechas y golpes, y todo el traje está cuidadosamente adornado con ricos grabados y detalles en relieve.  
 
 Esta armadura inusualmente pesada perteneció a Sarevok. Está encantada para proteger contra la magia.
 
 CARACTERÍSTICAS:
 
 Aptitudes poseídas:
-- Resistencia mágica: +30%
+  Resistencia mágica: +30%
 
 Clase de Armadura: -1
-Peso: 70
+Peso: 70 lbs
 Requisitos: Fuerza 15
 No utilizable por:
  Bardo
@@ -39,8 +39,8 @@ CARACTERÍSTICAS:
 
 Bonificación de clase de armadura: Ninguna
 Aptitudes poseídas:
-- Protección contra golpes críticos
-Peso: 2
+  Protección contra golpes críticos
+Peso: 2 lbs
 No utilizable por:
  Mago
  Bardo
@@ -54,9 +54,9 @@ CARACTERÍSTICAS:
 Bonificación de clase de armadura: Ninguna
 
 Aptitudes poseídas:
-- Protección contra golpes críticos
-- Resistencia mágica: +5%
-Peso: 2
+  Protección contra golpes críticos
+  Resistencia mágica: +5%
+Peso: 2 lbs
 No utilizable por:
  Mago
  Bardo
@@ -65,7 +65,7 @@ No utilizable por:
 @9 = ~Cofre de <CHARNAME>~
 @10 = ~Cofre de Imoen~
 
-/* nuevo para v2 */
+/* new for v2 */
 //#9774 cambiado
 @12 = ~¡Ese apestoso de Sarevok era realmente malvado, de verdad que lo era! ¡Asesinó a Scar y a Entar, e intentó asesinar a tantos otros! Merecía la muerte, ¡y gracias a <CHARNAME> llegó rápido!~
 //#9778 cambiado
@@ -73,34 +73,34 @@ No utilizable por:
 //#9781 cambiado
 @14 = ~¡Lo que Sarevok ha hecho es imperdonable! Me alegro de que <CHARNAME> encontrara a esa escoria antes de que pudiera hacer más daño.~
 //#9852 cambiado
-@15 = ~¡Bueno, yo nunca! ¿Puedes creer el descaro de ese tipo Sarevok? Después de la confianza que todos depositamos en él, resulta que no es más que el más bajo de los villanos. Me alegro de que lo atraparan y castigaran.~ 
+@15 = ~¡Vaya, nunca lo hubiera imaginado! ¿Podéis creer el descaro de ese tal Sarevok? Después de la confianza que todos depositamos en él, resulta que no es más que el más bajo de los villanos. Me alegro de que lo atraparan y castigaran.~ 
 //#9854 cambiado
-@16 = ~¿No eres <CHARNAME>? Vos y vuestros camaradas encajáis en la descripción. Pues bien, en nombre de aquellos a quienes represento, deseo agradeceros vuestras acciones. Si no hubiera sido por vuestro valor... Me estremezco al pensar lo que habría ocurrido en caso de una guerra contra Amn. ¡Gracias por capturar al villano Sarevok y detener sus planes!~
+@16 = ~¿No sois <CHARNAME>? Vos y vuestros camaradas encajáis en la descripción. Pues bien, en nombre de aquellos a quienes represento, deseo agradeceros vuestras acciones. Si no hubiera sido por vuestro valor... Me estremezco al pensar lo que habría ocurrido en caso de una guerra contra Amn. ¡Gracias por capturar al villano Sarevok y detener sus planes!~
 //#9855 changed
 @17 = ~¡Se está extendiendo como la pólvora! Todo el mundo habla de lo que pasó en el palacio. Por lo que he oído, ese Sarevok no es tan noble como nos quiere hacer creer. Intentó matar a los otros duques para apoderarse de la ciudad.~
 
-/* nuevo para v7 */
-@20 = ~Refugiada~ /* hembra*/
-@21 = ~Refugiado~ /* hombre*/
-@22 = ~Sanador del Puño Llameante~ /* hombre*/
-@23 = ~Explorador del Puño Llameante~ /* hombre*/
+/* new for v7 */
+@20 = ~Refugiada~ /* female*/
+@21 = ~Refugiado~ /* male*/
+@22 = ~Sanador del Puño Llameante~ /* male*/
+@23 = ~Explorador del Puño Llameante~ /* male*/
 
-/* nuevo para v9 */
+/* new for v9 */
 @24 = ~El nombre grabado artesanalmente en losas ornamentadas identifica esta entrada como la cripta de la familia Korlasz. Está bien cerrada y protegida mágicamente.~
-@25 = ~Saludos, héroe. Soy Fenster, el clérigo de palacio.~
+@25 = ~Saludos, héroe. Soy Fenster, el clérigo de palacio.~ ~Saludos, heroína. Soy Fenster, el clérigo de palacio.~
 @26 = ~¿En qué puedo serviros?~
 @27 = ~Dejadme ver lo que tenéis.~
 @28 = ~Nada en este momento.~
 @29 = ~Con mucho gusto.~
 @30 = ~No estoy disponible para servicios mientras atiendo a Imoen. Por favor, pedid ayuda divina en otra parte.~
-//@31: nombre tomado de #64284
+//@31: name taken from #64284
 @31 = ~Tumba de la familia de Korlasz~
 @32 = ~Cama de <CHARNAME>~
 
 /* sarevok_cleanup_more.tpa */
-/* #18345 cambiado */
+/* #18345 changed */
 @50 = ~Hay mucho que decir, pero no creo que tenga tiempo para entrar en detalles. Vivía en Candelero con mi padre Gorion. Hace poco nos vimos obligados a huir. Parece que hay alguien que me quiere muerto. En un intento de matarme, él... mató a mi padre.~
-/* #18351 cambiado */
+/* #18351 changed */
 @51 = ~Lamento haberos traído recuerdos tan dolorosos. Deseo ayudaros y, de paso, acabar también con los sueños que me persiguen. Tomad, coged esto. Adiós. Quizás volvamos a vernos.~
 @52 = ~¡Ah, <CHARNAME>! Me alivia que por fin todo haya vuelto a la normalidad. Después de ver la confianza que el Duque Eltan había depositado en vos, me sentí culpable por tener que seguir las órdenes de Angelo con respecto a vuestro arresto...~
 @53 = ~Y gracias, *gracias* por salvar a nuestro comandante.~

--- a/c#endlessbg1/translations/spanish/GAME_EE.TRA
+++ b/c#endlessbg1/translations/spanish/GAME_EE.TRA
@@ -1,4 +1,4 @@
-@1 = ~La armadura de placas es la mejor armadura que un guerrero puede comprar, tanto en apariencia como en protección. Las placas perfectamente ajustadas y entrelazadas están especialmente inclinadas para desviar flechas y golpes, y todo el traje está cuidadosamente adornado con ricos grabados y detalles en relieve. 
+@1 = ~La armadura de placas completa es la mejor armadura que un guerrero puede comprar, tanto en apariencia como en protección. Las placas perfectamente ajustadas y entrelazadas están especialmente inclinadas para desviar flechas y golpes, y todo el traje está cuidadosamente adornado con ricos grabados y detalles en relieve. 
 
 Esta inusual armadura pesada perteneció a Sarevok.
 
@@ -7,7 +7,7 @@ CARACTERÍSTICAS:
 Clase de Armadura: -1 (-5 contra cortante, -4 contra perforante y proyectil)
 Requisitos: Fuerza 15
 
-Peso: 70~
+Peso: 70 lbs~
 @2 = ~La armadura de placas completa es la mejor armadura que un guerrero puede comprar, tanto en apariencia como en protección. Las placas perfectamente ajustadas y entrelazadas están especialmente inclinadas para desviar flechas y golpes, y todo el traje está cuidadosamente adornado con ricos grabados y detalles en relieve. 
 
 Esta inusual armadura pesada perteneció a Sarevok. Está encantada para proteger contra la magia.
@@ -15,12 +15,12 @@ Esta inusual armadura pesada perteneció a Sarevok. Está encantada para proteger 
 CARACTERÍSTICAS:
 
 Aptitudes poseídas:
-- Resistencia mágica: +30%
+  Resistencia mágica: +30%
 
 Clase de Armadura: -1 (-5 contra cortante, -4 contra perforante y proyectil)
 Requisitos: Fuerza 15
 
-Peso: 70~
+Peso: 70 lbs~
 
 @6 = ~Esta clase de casco abierto, hecho de cuero reforzado o metal, cubre la mayor parte de la cabeza, excepto la cara y el cuello. Estos cascos suelen proteger la nariz.  
 
@@ -29,9 +29,9 @@ Este casco perteneció a Sarevok.
 CARACTERÍSTICAS:
 
 Aptitudes poseídas:
-- Protege contra golpes críticos
+  Protege contra golpes críticos
 
-Peso: 2~
+Peso: 2 lbs~
 @7 = ~Esta clase de casco abierto, hecho de cuero reforzado o metal, cubre la mayor parte de la cabeza, excepto la cara y el cuello. Estos cascos suelen proteger la nariz.  
 
 Este casco perteneció a Sarevok. Está encantado para proteger contra la magia.
@@ -39,7 +39,7 @@ Este casco perteneció a Sarevok. Está encantado para proteger contra la magia.
 CARACTERÍSTICAS:
 
 Aptitudes poseídas:
-- Protege contra golpes críticos
-- Resistencia mágica: +5%
+  Protege contra golpes críticos
+  Resistencia mágica: +5%
 
-Peso: 2~
+Peso: 2 lbs~

--- a/c#endlessbg1/translations/spanish/IMOEN_IN_GROUP_KD_EBG1.TRA
+++ b/c#endlessbg1/translations/spanish/IMOEN_IN_GROUP_KD_EBG1.TRA
@@ -1,21 +1,21 @@
-/* las líneas @0 - @17 son las mismas que en "imoen_forever/.../IMOEN_IN_GROUP_KD.TRA". */
-@0 = ~¡No me miréis así! Siempre quise dar la impresión de que sabía más que vos. Es lo que me dijo la duquesa Jannath, como si no lo supierais.~
+/* lines @0 - @17 are the same as in "imoen_forever/.../IMOEN_IN_GROUP_KD.TRA". */
+@0 = ~¡No me miréis así! Siempre quise dar la impresión de que sabía más que vos. Es lo que me dijo la Duquesa Jannath, como si no lo supierais.~
 @1 = ~¿Qué pasa con vos y la Duquesa Jannath?~
 @2 = ~Bueno, uhm... De alguna manera se ha encariñado conmigo desde que salvamos a los duques en la coronación de Sarevok. O la no coronación, para ser precisos.~
-@3 = ~Y, bueno... ella me dejó probar algunos de los hechizos mágicos, y... ¡es divertido! ¡Realmente podría hacerlo! Magia quiero decir. ¡Hice magia!~
+@3 = ~Y, bueno... ella me dejó probar algunos de los conjuros mágicos, y... ¡es divertido! ¡Realmente podría hacerlo! Magia quiero decir. ¡Hice magia!~
 @4 = ~Ella dijo que me ayudaría a desarrollar mis habilidades mágicas, y... He decidido que voy a aceptar la oferta. Ya sabéis, cuando todo esto termine.~
-@5 = ~Oh, para que lo sepáis - Prometí traerle cualquier pergamino arcano o tomo que pudiera encontrar aquí.~
+@5 = ~Oh, para que lo sepáis... Prometí traerle cualquier pergamino arcano o tomo que pudiera encontrar aquí.~
 @6 = ~¡Lo hicisteis! Sabía que lo haríais.~
 @7 = ~No puedo creer que esto haya terminado.~
 @8 = ~Lo hicimos juntos, Imoen.~
-@9 = ~No fuiste de mucha ayuda.~
+@9 = ~No fuisteis de mucha ayuda.~
 @10 = ~¡Sé lo que queréis decir!~
 @11 = ~Por mí está bien. No hay nada que temer, ¿verdad?~
-@12 = ~Los del Puño Llameante volverán arriba usando la cuerda que encontramos. Está justo al sur de aquí - te lleva directamente a la entrada.~
+@12 = ~Los del Puño Llameante volverán arriba usando la cuerda que encontramos. Está justo al sur de aquí, os lleva directamente a la entrada.~
 @13 = ~¡Mirad esos tomos y libros sobre Bhaal! La Duquesa Jannath saltaría de alegría si los consiguiera. Bueno, en realidad no lo haría, es demasiado digna para eso, pero... ¿Puedo tomar estos para ella? ¿Por favor?~
 @14 = ~Claro. No sé cómo podrían serme útiles.~
 @15 = ~No, quiero quedármelos por ahora.~
 @16 = ~Bien, pero decidme si cambiáis de opinión, ¿de acuerdo?~
 @17 = ~Tomad la investigación sobre Bhaal que encontramos para la Duquesa Jannath, Imoen.~
 
-@200 = ~Escalad la cuerda cuando estéis listos para regresar al palacio. Estaremos detrás de vos.~
+@200 = ~Subid por la cuerda cuando estéis listo para regresar al palacio. Estaremos detrás de vos.~ ~Subid por la cuerda cuando estéis lista para regresar al palacio. Estaremos detrás de vos.~

--- a/c#endlessbg1/translations/spanish/JOURNAL.TRA
+++ b/c#endlessbg1/translations/spanish/JOURNAL.TRA
@@ -1,21 +1,21 @@
 /* entradas de diario */
-@10000 = ~La Espada de Sarevok
+@10000 = ~La espada de Sarevok
 
 Un Djinn se manifestó justo después de que abandonara la ciudad subterránea y me arrebató la espada de Sarevok. Dijo que tenía que obedecer a "su amo". ¿Quién podría tener interés en tomar la espada de Sarevok? Parece que aún hay gente que lo sigue... O que quiere beneficiarse de su poder.~
-@10001 = ~La Espada de Sarevok
+@10001 = ~La espada de Sarevok
 
-He entregado la Espada de Sarevok a los Duques. La consideran un símbolo de su poder y desean mantenerlo alejado de cualquier seguidor que lo considere un objeto de valor simbólico de su líder caído Sarevok.~
+He entregado la Espada de Sarevok a los duques. La consideran un símbolo de su poder y desean mantenerlo alejado de cualquier seguidor que lo considere un objeto de valor simbólico de su líder caído Sarevok.~
 @10002 = ~Mis aposentos en el Palacio Ducal
 
-He sido nombrado "Héroe de Baldur's Gate" y me han ofrecido alojamiento en el último piso del Palacio Ducal.~ ~Mis aposentos en el Palacio Ducal
+He sido nombrado "Héroe de Puerta de Baldur" y me han ofrecido alojamiento en el último piso del Palacio Ducal.~ ~Mis aposentos en el Palacio Ducal
 
-He sido nombrada "Heroína de Baldur's Gate" y me han ofrecido alojamiento en el último piso del Palacio Ducal.~
+He sido nombrada "Heroína de Puerta de Baldur" y me han ofrecido alojamiento en el último piso del Palacio Ducal.~
 @10003 = ~Mi cofre personal en el Palacio Ducal 
 
-El cofre del extremo izquierdo de la sala noroeste del último piso del Palacio Ducal es mi cofre personal, todo lo que ponga ahí permanecerá en él mientras resida en el Palacio.~
+El cofre del extremo izquierdo de la sala noroeste del último piso del Palacio Ducal es mi cofre personal, todo lo que ponga ahí permanecerá en él mientras resida en el palacio.~
 @10004 = ~El cofre personal de Imoen en el Palacio Ducal 
 
-El cofre del extremo izquierdo de la sala sureste de la última planta del Palacio Ducal es el cofre personal de Imoen, todo lo que metamos ahí permanecerá en él mientras residamos en el Palacio.~
+El cofre del extremo izquierdo de la sala sureste de la última planta del Palacio Ducal es el cofre personal de Imoen, todo lo que metamos ahí permanecerá en él mientras residamos en el palacio.~
 @10005 = ~Imoen está en el Palacio Ducal
 
 Imoen reside en el Palacio Ducal, en el último piso. La encontraré allí si quiero que vuelva conmigo.~
@@ -25,27 +25,27 @@ Y de nuevo Elminster hizo su aparición tras la muerte de Sarevok, y por fin veo 
 @10007 = ~Refugiados del lejano norte
 
 Refugiados estan llegando a Puerta de Baldur, hablando sobre algunos acontecimientos brutales al norte en Páramo Alto. Se han quemando granjas y pequeñas aldeas.~
-@10008 = ~La Espada de Sarevok
+@10008 = ~La espada de Sarevok
 
-El Duque Belt me pidió que le diera la Espada de Sarevok. Los Duques la ven como un símbolo del poder de Sarevok y desean mantenerla alejada de cualquier seguidor que lo considere un objeto de valor simbólico de su líder caído.~
+El Duque Belt me pidió que le diera la espada de Sarevok. Los duques la ven como un símbolo del poder de Sarevok y desean mantenerla alejada de cualquier seguidor que lo considere un objeto de valor simbólico de su líder caído.~
 
-@10009 = ~La Espada de Sarevok~
+@10009 = ~La espada de Sarevok~
 
 /* nuevo para v3 */
-@10010 = ~La Espada de Sarevok
+@10010 = ~La espada de Sarevok
 
-Al parecer, la Espada de Sarevok fue robada del Palacio Ducal por sus últimos seguidores y vendida a Athkatla. Parece que no supieron custodiarla bien. ¡Mala suerte!~
-@10011 = ~La Espada de Sarevok
+Al parecer, la espada de Sarevok fue robada del Palacio Ducal por sus últimos seguidores y vendida a Athkatla. Parece que no supieron custodiarla bien. ¡Mala suerte!~
+@10011 = ~La espada de Sarevok
 
-He obtenido la Espada de Sarevok de nuevo. Aún le falta mucho de su antiguo poder, pero al menos ahora puedo manejarla.~
+He obtenido la espada de Sarevok de nuevo. Aún le falta mucho de su antiguo poder, pero al menos ahora puedo manejarla.~
 
 /* nuevo para v9 */
 /* #31288 */
-@10012 = ~Contrario a la Ley
+@10012 = ~En conflicto con la ley
 
 Sarevok está muerto. Este capítulo de mi vida ha terminado.~
 /* #31374 */
-@10013 = ~Tras la pista de Sarevok
+@10013 = ~Siguiendo la pista a Sarevok
 
 Sarevok está muerto. Este capítulo de mi vida ha terminado.~
 /* #31400 */
@@ -53,18 +53,18 @@ Sarevok está muerto. Este capítulo de mi vida ha terminado.~
 
 Sarevok está muerto. Este capítulo de mi vida ha terminado.~
 /* #31416 */
-@10015 = ~El Ascenso de Sarevok
+@10015 = ~El auge de Sarevok
 
 Sarevok está muerto. Este capítulo de mi vida ha terminado.~
 
 /* new for v18 */
-@10016 = ~Retorno al Palacio
+@10016 = ~Retorno al palacio
 
 Sarevok ha sido derrotado. Debería volver al Palacio Ducal y hablar con los duques.~
-@10017   = ~Retorno al Palacio
+@10017   = ~Retorno al palacio
 
-Tan pronto como esté listo, debo hablar con los duques sobre lo que quieren que haga ahora.~ ~Retorno al Palacio
+Tan pronto como esté listo, debo hablar con los duques sobre lo que quieren que haga ahora.~ ~Retorno al palacio
 
 Tan pronto como esté lista, debo hablar con los duques sobre lo que quieren que haga ahora.~
-@10018   = ~Retorno al Palacio~
+@10018   = ~Retorno al palacio~
 

--- a/c#endlessbg1/translations/spanish/setup.tra
+++ b/c#endlessbg1/translations/spanish/setup.tra
@@ -1,39 +1,39 @@
-@5000 = ~Este mod sólo es compatible con BG:EE, SoD, BGT, and EET.~
+@5000 = ~Este mod solo es compatible con BG:EE, SoD, BGT, and EET.~
 @5001 = ~Endless BG1: Componente principal (Requerido)~
-@5002 = ~Más sabor a Héroe de Puerta de Baldur (Incluye residencia del PC dentro del palacio)~
+@5002 = ~Mas sabor a Heroe de Puerta de Baldur (Incluye residencia del PC dentro del palacio)~
 @5003 = ~Endless BG1: Componente principal es requerido para este componente~
 @5004 = ~Imoen y la Duquesa Jannath (Imoen obtiene residencia dentro del palacio)~
-@5005 = ~El Duque Eltan está en el palacio~
-@5006 = ~El Puño Llameante después del combate final~
+@5005 = ~El Duque Eltan esta en el palacio~
+@5006 = ~El Puño Llameante despues del combate final~
 @5007 = ~Elminster hace una aparición~
-@5008 = ~Objetos únicos de Sarevok~
+@5008 = ~Objetos unicos de Sarevok~
 @5009 = ~Los primeros refugiados llegan a Puerta de Baldur~
-@5010 = ~Ophyllis el tesorero está dentro de la mazmorra del palacio~
+@5010 = ~Ophyllis el tesorero esta dentro de la mazmorra del palacio~
 @5011 = ~Denkod del Gremio de Ladrones comenta la muerte de Sarevok~
-@5012 = ~Este componente sólo es compatible con SoD y EET.~
-@5013 = ~Este componente sólo es compatible con BG:EE, SoD, BGT y EET.~
+@5012 = ~Este componente solo es compatible con SoD y EET.~
+@5013 = ~Este componente solo es compatible con BG:EE, SoD, BGT y EET.~
 @5014 = ~La Espada de Sarevok~
-@5015 = ~La versión de Jastey~
+@5015 = ~La version de Jastey~
 @5016 = ~Texto BG1 restaurado~
 
-/* nuevo para v3 */
+/* new for v3 */
 @5017 = ~Saltar laberinto de ladrones una vez muerto Sarevok~
-@5018 = ~Breve homenaje público al Héroe~
-@5019 = ~Endless BG1: "Más sabor a Héroe de Puerta de Baldur" Componente necesario para este componente~
+@5018 = ~Breve homenaje publico al heroe~
+@5019 = ~Endless BG1: "Mas sabor a Heroe de Puerta de Baldur" Componente necesario para este componente~
 
-/* nuevo para v5 */
+/* new for v5 */
 @5020 = ~El componente de bg1re "Duke Eltan's Spare Minute" necesita ser instalado despues de ebg1.~
 @5021 = ~ebg1 debe instalarse antes de Transitions.~
 @5022 = ~Este componente de ebg1 ya ha sido sustituido por Transitions.~
 
-/* nuevo para v7 */
-@5023 = ~Este mod debe instalarse antes que EET_End en su instalación de EET.~
+/* new for v7 */
+@5023 = ~Este mod debe instalarse antes que EET_End en su instalacion de EET.~
 
-/* nuevo para v9 */
-@5024 = ~La mazmorra de Korlasz está en BG1~
+/* new for v9 */
+@5024 = ~La mazmorra de Korlasz esta en BG1~
 @5025 = ~Imoen4Ever's "Imoen permanece en el grupo en la mazmorra de Korlasz" necesita ser desinstalado para esto.~
-@5026 = ~Fenster el sacerdote de palacio está en el palacio~
-@5027 = ~La capitana Corwin está en el palacio~
+@5026 = ~Fenster el sacerdote de palacio esta en el palacio~
+@5027 = ~La capitana Corwin esta en el palacio~
 
 /* new for v18 */
 @5028  = ~Modmerge o DLC Merger son necesarios para poder instalar mods en este juego.~


### PR DESCRIPTION
- Spanish version revised, by ElGamerViejuno.
- "Korlasz' Dungeon is in BG1": Fixed incompatibility with EE Fixpack that lead to intro cutscene in Korlasz' Tomb not ending.
- In case the PC did not talk to him, Husam will no longer be waiting in NE Baldur's Gate after Sarevok is defeated to point the PC to Slythe and Kristin.
- Added install checks so components "More Flavor to Hero of Baldur's Gate" and "Imoen and Duke Jannath" cannot be installed after component "Extended Law System" from Jarl's Adventure Pack, by Ychap.